### PR TITLE
Update the 0.11.1 Changelog and Readme.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to the **daily-android** SDK will be documented in this file
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.11.1] - 2023-10-27
+
+### Fixed
+
+- Joining a call where a recording with participant-selection properties specified is ongoing will no longer fail.
+
 ## [0.11.0] - 2023-10-05
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ To depend on the Daily Client package, you can add this package via maven, for e
 
 ```
 dependencies {
-    implementation 'co.daily:client:0.11.0'
+    implementation 'co.daily:client:0.11.1'
     // ... other dependencies
 }
 ```


### PR DESCRIPTION
## [0.11.1] - 2023-10-27

### Fixed

- Joining a call where a recording with participant-selection properties specified is ongoing will no longer fail.